### PR TITLE
Fix rendering of links to UNITE ITS database files

### DIFF
--- a/_wiki/unite_its_database.md
+++ b/_wiki/unite_its_database.md
@@ -7,9 +7,9 @@ There are full "UNITE+INSD" datasets available in mothur format:
 This dataset comprises of all quality filtered unclustered UNITE + INSD
 sequences (311 302) included in the UNITE Species Hypotheses.
 
-![ unite\_its\_02.zip](https://mothur.s3.us-east-2.amazonaws.com/wiki/unite_its_02.zip)
+[unite\_its\_02.zip](https://mothur.s3.us-east-2.amazonaws.com/wiki/unite_its_02.zip)
 
 This dataset comprises of all quality filtered unclustered UNITE + INSD
 sequences (442 706).
 
-![ unite\_its\_s\_02.zip](https://mothur.s3.us-east-2.amazonaws.com/wiki/unite_its_s_02.zip)
+[unite\_its\_s\_02.zip](https://mothur.s3.us-east-2.amazonaws.com/wiki/unite_its_s_02.zip)


### PR DESCRIPTION
Remove markdown for figures and replaced with markdown for files, close #24