### PR TITLE
Improve OptiFit documentation

### DIFF
--- a/CITATION.md
+++ b/CITATION.md
@@ -2,12 +2,12 @@
 
 To cite mothur in a scholarly article, please use:
 
-> Schloss, P.D., et al., Introducing mothur: Open-source, platform-independent, community-supported software for describing and comparing microbial communities. Appl Environ Microbiol, 2009. 75(23):7537-41
+> Schloss PD et al. 2009. Introducing mothur: Open-source, platform-independent, community-supported software for describing and comparing microbial communities. Applied and Environmental Microbiology 75:7537–7541.
 
 A BibTeX entry for LaTeX users:
 
 ```TeX
-@article {Schloss7537,
+@article{schloss_introducting_2009,
 	author = {Schloss, Patrick D. and Westcott, Sarah L. and Ryabin, Thomas and Hall, Justine R. and Hartmann, Martin and Hollister, Emily B. and Lesniewski, Ryan A. and Oakley, Brian B. and Parks, Donovan H. and Robinson, Courtney J. and Sahl, Jason W. and Stres, Blaz and Thallinger, Gerhard G. and Van Horn, David J. and Weber, Carolyn F.},
 	title = {Introducing mothur: Open-Source, Platform-Independent, Community-Supported Software for Describing and Comparing Microbial Communities},
 	volume = {75},
@@ -16,10 +16,48 @@ A BibTeX entry for LaTeX users:
 	year = {2009},
 	doi = {10.1128/AEM.01541-09},
 	publisher = {American Society for Microbiology Journals},
-	abstract = {mothur aims to be a comprehensive software package that allows users to use a single piece of software to analyze community sequence data. It builds upon previous tools to provide a flexible and powerful software package for analyzing sequencing data. As a case study, we used mothur to trim, screen, and align sequences; calculate distances; assign sequences to operational taxonomic units; and describe the α and β diversity of eight marine samples previously characterized by pyrosequencing of 16S rRNA gene fragments. This analysis of more than 222,000 sequences was completed in less than 2 h with a laptop computer.},
 	issn = {0099-2240},
 	URL = {https://aem.asm.org/content/75/23/7537},
 	eprint = {https://aem.asm.org/content/75/23/7537.full.pdf},
 	journal = {Applied and Environmental Microbiology}
 }
 ```
+
+## Cite OptiClust
+
+If you use the OptiClust method in the `cluster` or `cluster.split` commands,
+please also cite the OptiClust paper:
+
+> Westcott SL, Schloss PD. 2017. OptiClust, an Improved Method for Assigning Amplicon-Based Sequence Data to Operational Taxonomic Units. mSphere 2:e00073-17.
+
+A BibTeX entry for LaTeX users:
+
+```TeX
+@article{westcott_opticlust_2017,
+    title = {{{OptiClust}}, an {{Improved Method}} for {{Assigning Amplicon}}-{{Based Sequence Data}} to {{Operational Taxonomic Units}}},
+    author = {Westcott, Sarah L. and Schloss, Patrick D.},
+    editor = {McMahon, Katherine},
+    year = {2017},
+    month = mar,
+    volume = {2},
+    number = {2},
+    pages = {e00073-17},
+    issn = {2379-5042},
+    doi = {10.1128/mSphereDirect.00073-17},
+    journal = {mSphere}
+}
+```
+
+<!-- TODO: add citation for OptiFit once it's published.
+## Cite OptiFit
+
+If you use the `cluster.fit` command, please also cite the OptiFit paper:
+
+> TODO
+
+A BibTeX entry for LaTeX users:
+
+```TeX
+@article{TODO}
+```
+-->

--- a/_wiki/cluster.fit.md
+++ b/_wiki/cluster.fit.md
@@ -5,24 +5,30 @@ redirect_from: '/wiki/Cluster.fit.html'
 ---
 The **cluster.fit** command can be used to assign
 sequences to OTUs or fit sequences to existing OTUs. Currently, mothur
-has two options for doing this:
+has two methods for doing this:
 
 -   Closed: Fit reads to existing OTUs, scrapping
     any reads unable to be fitted.
 -   Open: Fit reads to existing OTUs, any unfitted
     reads are clustered separately into new OTUs.
 
-If there is an algorithm that you would like to see implemented, please
-consider either contributing to the mothur project or contacting the
-developers and we'll see what we can do. The open method is the default
-option. For this tutorial you should download the [
-OptiFitDataSets.zip](https://mothur.s3.us-east-2.amazonaws.com/wiki/optifitdatasets.zip) file and
-decompress it.
+For this tutorial you should download the 
+[OptiFitDataSets.zip](https://mothur.s3.us-east-2.amazonaws.com/wiki/optifitdatasets.zip) 
+file and decompress it.
 
+<!-- TODO: add citation for OptiFit once it's published.
+If you use the `cluster.fit` command, please cite the OptiFit paper:
+
+> TODO
+
+See the 
+[citation file](https://github.com/mothur/mothur/blob/master/CITATION.md#cite-optifit) for a 
+BibTeX entry.
+-->
 
 ## Default settings
 
-You may run the command in denovo or reference mode. Either a
+You may run the command in _de novo_ or reference mode. Either a
 [phylip-formatted distance
 matrix](/wiki/phylip-formatted_distance_matrix) or a
 [column-formatted distance
@@ -33,13 +39,13 @@ us know and we can work with you to incorporate that feature into
 mothur. Because the phylip format is so popular most software can
 generate this format for you.
 
-### denovo fitting
+### _de novo_ fitting
 
-The denovo method allows you to use your dataset as a reference. mothur
-will randomly select a portion of your dataset to be the reference. The
-reference is then clustered and the remaining sequences are fitted into
-the "reference" otus. This process is repeated x number of times with
-the best list file chosen as the output.
+The _de novo_ method allows you to use your dataset as a reference. mothur
+will randomly select a portion of your dataset to be the reference. 
+The reference is then clustered with [OptiClust](/wiki/cluster), 
+and the remaining sequences are fitted to the reference otus with OptiFit.
+This process is repeated n times with the best OTU assignments chosen as the output.
 
     mothur > cluster.fit(column=marine.0_2.01.dist, count=marine.0_2.01.count_table)
 
@@ -50,12 +56,14 @@ The best sensspec results were found on the 4th iteration:
 
 ### reference fitting
 
-The reference fitting methods use a reference and fit the new dataset's sequences into the reference otus. 
-Perhaps you have a study where 20 patients were sampled, and you want to see how a
-new patient's data would fit in with the existing results. There are several ways to 
-fit new data to an existing dataset. 
+The reference fitting methods use a reference list and fit the new dataset's 
+sequences into the reference otus. 
+Perhaps you have a study where 20 patients were sampled and you clustered 
+sequences into _de novo_ OTUs with [OptiClust](/wiki/cluster), and you want to 
+fit a new patient's data to the existing OTUs. 
+There are several ways to fit new data to an existing dataset. 
 
-The reference method uses a user provided reference and fits the new
+The reference method takes a user-provided reference and fits the new
 dataset's sequences into the reference otus.  
 
     mothur > unique.seqs(fasta=silva.v4.fasta, format=count)
@@ -70,9 +78,11 @@ The sens.spec results:
 
 or
 
-The accnos parameter may be used to indicate a subset of your data as the reference. 
-You can merge the count and fasta files containing the old and new data. Mothur will cluster the references
-using optiClust and then fit the query reads to the reference OTUs.
+The accnos parameter may be used to indicate a subset of your data as the 
+reference. 
+You can merge the count and fasta files containing the old and new data. 
+Mothur will cluster the references using [OptiClust](/wiki/cluster) and then fit 
+the query reads to the reference OTUs.
      
      mothur > list.seqs(fasta=reference.fasta)
      mothur > merge.files(input=reference.fasta-query.fasta, output=combined.fasta)
@@ -83,7 +93,8 @@ using optiClust and then fit the query reads to the reference OTUs.
 or
 
 The reflist parameter can be used to provide a list file for the references. 
-This can be helpful if you want to use existing OTUs from an earlier run of mothur.
+This can be helpful if you want to use existing OTUs from an earlier run of 
+mothur's OptiClust algorithm.
     
      mothur > merge.files(input=reference.fasta-query.fasta, output=combined.fasta)
      mothur > merge.count(count=reference.count_table-query.count_table, output=combined.count_table)
@@ -172,7 +183,7 @@ artificially inflate the matrix to its full size.
 
 ### count
 
-The [ count](/wiki/Count_File) file is similar to the name file in
+The [count](/wiki/Count_File) file is similar to the name file in
 that it is used to represent the number of duplicate sequences for a
 given representative sequence. mothur will use this information to form
 the correct OTU's. Unlike, when you use a name file the list file
@@ -183,23 +194,23 @@ count file in downstream analysis with the list file.
 
 ### reffasta
 
-The reffasta parameter allows you to enter a fasta file for your
+The `reffasta` parameter allows you to enter a fasta file for your
 reference dataset.
 
 ### refcolumn && refphylip
 
-The refcolumn and refphylip parameters allow you to enter a reference
+The `refcolumn` and `refphylip` parameters allow you to enter a reference
 data distance file, to reduce processing time. It is not required, but
 recommended when using reference mode.
 
 ### reflist
 
-The reflist parameter allows you to enter a list file for your reference
+The `reflist` parameter allows you to enter a list file for your reference
 dataset.
 
 ### accnos
 
-The accnos parameter allows you to assign reference seqeunces by name.
+The `accnos` parameter allows you to assign reference seqeunces by name.
 This can save time by allowing you to provide a distance matrix
 containing all the sequence distances rather than a sample matrix and
 reference matrix and mothur calculating the distances between the sample
@@ -207,13 +218,28 @@ and reference.
 
 ### method
 
-The options for the method parameter are open or closed. The default is
+The options for the `method` parameter are open or closed. The default is
 open.
 
 -   Closed: Fit reads to existing OTUs, scrapping
     any reads unable to be fitted.
 -   Open: Fit reads to existing OTUs, any unfitted
-    reads are clustered separately into new OTUs.
+    reads are clustered separately into new OTUs with OptiClust.
+
+### printref
+
+The `printref` option controls whether the reference sequences are printed to 
+list file and included in the final [sensspec](/wiki/sens.spec) calculations.
+Set `printref=t` (true) to include the reference sequences, 
+or `printref=f` (false) to exclude the reference sequences.
+
+We recommend using `printref=f` when the reference sequences are from a public 
+external database such as SILVA or Greengenes, so that only the sequences from 
+your dataset of interest are included in the list and sensspec files.
+
+Using `printref=t` may be more appropriate when the reference is created by
+selecting a random sample from a dataset followed by using the remaining 
+sequences as the query for OptiFit.
 
 ### metric
 
@@ -249,7 +275,7 @@ algorithm. Default=100.
 
 ### denovoiters
 
-The denovoiters parameter allow you to set the maxiters for the denovo
+The denovoiters parameter allow you to set the maxiters for the _de novo_
 sampling. Default=10.
 
 ### cutoff

--- a/_wiki/cluster.fit.md
+++ b/_wiki/cluster.fit.md
@@ -22,7 +22,7 @@ If you use the `cluster.fit` command, please cite the OptiFit paper:
 > TODO
 
 See the 
-[citation file](https://github.com/mothur/mothur/blob/master/CITATION.md#cite-optifit) 
+[citation file](https://github.com/mothur/mothur.github.io/blob/master/CITATION.md#cite-optifit) 
 for a BibTeX entry.
 -->
 

--- a/_wiki/cluster.fit.md
+++ b/_wiki/cluster.fit.md
@@ -22,8 +22,8 @@ If you use the `cluster.fit` command, please cite the OptiFit paper:
 > TODO
 
 See the 
-[citation file](https://github.com/mothur/mothur/blob/master/CITATION.md#cite-optifit) for a 
-BibTeX entry.
+[citation file](https://github.com/mothur/mothur/blob/master/CITATION.md#cite-optifit) 
+for a BibTeX entry.
 -->
 
 ## Default settings

--- a/_wiki/cluster.fit.md
+++ b/_wiki/cluster.fit.md
@@ -243,14 +243,15 @@ sequences as the query for OptiFit.
 
 ### metric
 
-The metric parameter allows to select the metric in the opticluster
-method. Options are Matthews correlation coefficient (mcc), sensitivity
-(sens), specificity (spec), true positives + true negatives (tptn),
-false positives + false negatives (fpfn), true positives (tp), true
-negative (tn), false positive (fp), false negative (fn), f1score
-(f1score), accuracy (accuracy), positive predictive value (ppv),
-negative predictive value (npv), false discovery rate (fdr).
-Default=mcc.
+The `metric` parameter allows to select the metric to optimize in the OptiClust
+method. Options are Matthews correlation coefficient (`mcc` - default), 
+sensitivity (`sens`), specificity (`spec`), 
+true positives + true negatives (`tptn`),
+false positives + false negatives (`fpfn`), true positives (`tp`), 
+true negative (`tn`), false positive (`fp`), false negative (`fn`), 
+f1score (`f1score`), accuracy (`accuracy`), positive predictive value (`ppv`),
+negative predictive value (`npv`), false discovery rate (`fdr`).
+The default is `mcc`.
 
     mothur > cluster.fit(column=marine.0_2.01.dist, count=marine.0_2.01.count_table, metric=tptn)
 
@@ -259,29 +260,29 @@ Default=mcc.
 
 ### fitpercent
 
-The fitpercent parameter allow you to set percentage of reads to be
+The `fitpercent` parameter allow you to set percentage of reads to be
 fitted. Default=50. Max=100, min=0.01.
 
 ### delta
 
-The delta parameter allows to set the stable value for the metric in the
+The `delta` parameter allows to set the stable value for the metric in the
 opticluster algorithm. Default delta=0.0001. To reach a full
 convergence, set delta=0.
 
 ### iters
 
-The iters parameter allow you to set the maxiters for the opticluster
+The `iters` parameter allows you to set the maxiters for the OptiClust
 algorithm. Default=100.
 
 ### denovoiters
 
-The denovoiters parameter allow you to set the maxiters for the _de novo_
+The `denovoiters` parameter allow you to set the maxiters for the _de novo_
 sampling. Default=10.
 
 ### cutoff
 
 With the opticlust method the list file is created for the cutoff you
-set. The default cutoff is 0.03.
+set. The default `cutoff` is 0.03.
 
 ### precision
 
@@ -293,9 +294,11 @@ cluster.fit() command:
 ### Variability
 
 You may notice that if you run the same command multiple times for the
-same dataset you might get slightly different out for some distances:
+same dataset, you might get slightly different output.
 
-The variability is caused by the randomization of the sequences.
+The variability is caused by randomizing the order of the sequences before 
+clustering begins. You can set a seed to get reproducible results
+with the [`set.seed`](/wiki/set.seed) command prior to running `cluster.fit`.
 
 ## Revisions
 

--- a/_wiki/cluster.md
+++ b/_wiki/cluster.md
@@ -32,7 +32,7 @@ please cite the OptiClust paper:
 > Westcott SL, Schloss PD. 2017. OptiClust, an Improved Method for Assigning Amplicon-Based Sequence Data to Operational Taxonomic Units. mSphere 2:e00073-17.
 
 See the 
-[citation file](https://github.com/mothur/mothur/blob/master/CITATION.md#cite-opticlust) 
+[citation file](https://github.com/mothur/mothur.github.io/blob/master/CITATION.md#cite-opticlust) 
 for a BibTeX entry.
 
 ## Default settings

--- a/_wiki/cluster.md
+++ b/_wiki/cluster.md
@@ -437,7 +437,9 @@ same dataset you might get slightly different out for some distances:
     7  0   0.03    1170    0.03    31932   7051142 8524    20508   0.608924    0.998793    0.789302    0.9971  0.210698    0.995918    0.69131 0.687478    
     8  0   0.03    1170    0.03    31905   7051185 8481    20535   0.60841 0.998799    0.790001    0.997096    0.209999    0.99592 0.691326    0.687415    
 
-The variability is caused by the randomization of the sequences.
+The variability is caused by randomizing the order of the sequences before 
+clustering begins. You can set a seed to get reproducible results
+with the [`set.seed`](/wiki/set.seed) command prior to running `cluster.fit`.
 
 ## Revisions
 

--- a/_wiki/cluster.md
+++ b/_wiki/cluster.md
@@ -7,22 +7,33 @@ Once a distance matrix gets read into mothur, the
 **cluster** command can be used to assign sequences to
 OTUs. Presently, mothur implements three clustering methods:
 
--   Nearest neighbor (nearest): Each of the sequences within an OTU are at most X% distant from the most similar sequence in the OTU.
--   Furthest neighbor (furthest): All of the
+-   OptiClust (`opti`): OTUs are assembled using metrics to determine the 
+    quality of clustering (the default setting).
+-   Nearest neighbor (`nearest`): Each of the sequences within an OTU are at 
+    most X% distant from the most similar sequence in the OTU.
+-   Furthest neighbor (`furthest`): All of the
     sequences within an OTU are at most X% distant from all of the other
     sequences within the OTU.
--   Average neighbor (average): This method is a
+-   Average neighbor (`average`): This method is a
     middle ground between the other two algorithms.
--   AGC (agc):
--   DGC (dgc):
--   Opti (opti): OTUs are assembled using metrics to determine the quality of clustering (the default setting).
--   Unique: Creates a list file from a name or count file where every unique sequence is assigned to it's own OTU
+-   AGC (`agc`): Abundance-based greedy clustering.
+-   DGC (`dgc`): Distance-based greedy clustering.
+-   Unique (`unique`): Creates a list file from a name or count file where every unique 
+    sequence is assigned to it's own OTU (i.e. Amplicon Sequence Variant)
 
 If there is an algorithm that you would like to see implemented, please
 consider either contributing to the mothur project or contacting the
 developers and we'll see what we can do. The opticlust algorithm is the
 default option. For this tutorial you should download the [Final.zip](https://mothur.s3.us-east-2.amazonaws.com/wiki/final.zip) file and decompress it.
 
+If you use the OptiClust method (`opti`) in this command,
+please cite the OptiClust paper:
+
+> Westcott SL, Schloss PD. 2017. OptiClust, an Improved Method for Assigning Amplicon-Based Sequence Data to Operational Taxonomic Units. mSphere 2:e00073-17.
+
+See the 
+[citation file](https://github.com/mothur/mothur/blob/master/CITATION.md#cite-opticlust) for a 
+BibTeX entry.
 
 ## Default settings
 

--- a/_wiki/cluster.md
+++ b/_wiki/cluster.md
@@ -32,8 +32,8 @@ please cite the OptiClust paper:
 > Westcott SL, Schloss PD. 2017. OptiClust, an Improved Method for Assigning Amplicon-Based Sequence Data to Operational Taxonomic Units. mSphere 2:e00073-17.
 
 See the 
-[citation file](https://github.com/mothur/mothur/blob/master/CITATION.md#cite-opticlust) for a 
-BibTeX entry.
+[citation file](https://github.com/mothur/mothur/blob/master/CITATION.md#cite-opticlust) 
+for a BibTeX entry.
 
 ## Default settings
 

--- a/_wiki/cluster.split.md
+++ b/_wiki/cluster.split.md
@@ -337,7 +337,9 @@ same dataset you might get slightly different out for some distances:
     label  cutoff  tp  tn  fp  fn  sensitivity specificity ppv npv fdr accuracy    mcc f1score
     0.03   0.03    31313   7051732 8028    21033   0.5982  0.9989  0.7959  0.997   0.2041  0.9959  0.6881  0.683
 
-The variability is caused by the randomization of the sequences.
+The variability is caused by randomizing the order of the sequences before 
+clustering begins. You can set a seed to get reproducible results
+with the [`set.seed`](/wiki/set.seed) command prior to running `cluster.split`.
 
 ## Revisions
 

--- a/_wiki/cluster.split.md
+++ b/_wiki/cluster.split.md
@@ -4,21 +4,22 @@ tags: 'commands'
 redirect_from: '/wiki/Cluster.split.html'
 ---
 The **cluster.split** command can be used to assign sequences to OTUs and
-outputs a .list file. It splits large datasets into smaller
-peices \...
+outputs a .list file.
+There are two parts to the **cluster.split** command: splitting datasets into distinct groups based on taxonomic classifications, and then clustering within the groups.
 
--   Nearest neighbor (nearest): Each of the
-    sequences within an OTU are at most X% distant from the most similar
-    sequence in the OTU.
--   Furthest neighbor (furthest): All of the
+-   OptiClust (`opti`): OTUs are assembled using metrics to determine the 
+    quality of clustering (the default setting).
+-   Nearest neighbor (`nearest`): Each of the sequences within an OTU are at 
+    most X% distant from the most similar sequence in the OTU.
+-   Furthest neighbor (`furthest`): All of the
     sequences within an OTU are at most X% distant from all of the other
     sequences within the OTU.
--   Average_neighbor (average): This method is a
+-   Average neighbor (`average`): This method is a
     middle ground between the other two algorithms.
--   AGC (agc):
--   DGC (dgc):
--   Opti (opti): OTUs are assembled using metrics to
-    determine the quality of clustering (default).
+-   AGC (`agc`): Abundance-based greedy clustering.
+-   DGC (`dgc`): Distance-based greedy clustering.
+-   Unique (`unique`): Creates a list file from a name or count file where every unique 
+    sequence is assigned to it's own OTU (i.e. Amplicon Sequence Variant)
 
 If there is an algorithm that you would like to see implemented, please
 consider either contributing to the mothur project or contacting the
@@ -26,10 +27,14 @@ developers and we'll see what we can do. The opticlust algorithm is the
 default option. For this tutorial you should download the [
 Final.zip](https://mothur.s3.us-east-2.amazonaws.com/wiki/final.zip) file and decompress it.
 
+If you use the OptiClust method (`opti`) in this command,
+please cite the OptiClust paper:
 
-There are two part to the **cluster.split** command the splitting of your
-files into distinct groupings and the clustering of these groupings.
+> Westcott SL, Schloss PD. 2017. OptiClust, an Improved Method for Assigning Amplicon-Based Sequence Data to Operational Taxonomic Units. mSphere 2:e00073-17.
 
+See the 
+[citation file](https://github.com/mothur/mothur/blob/master/CITATION.md#cite-opticlust) for a 
+BibTeX entry.
 ## Splitting your files
 
 The **cluster.split** command splits your dataset into groups based the sequences classifications. You need to provide

--- a/_wiki/cluster.split.md
+++ b/_wiki/cluster.split.md
@@ -33,7 +33,7 @@ please cite the OptiClust paper:
 > Westcott SL, Schloss PD. 2017. OptiClust, an Improved Method for Assigning Amplicon-Based Sequence Data to Operational Taxonomic Units. mSphere 2:e00073-17.
 
 See the 
-[citation file](https://github.com/mothur/mothur/blob/master/CITATION.md#cite-opticlust) for a 
+[citation file](https://github.com/mothur/mothur.github.io/blob/master/CITATION.md#cite-opticlust) for a 
 BibTeX entry.
 ## Splitting your files
 

--- a/_wiki/mothur_manual.md
+++ b/_wiki/mothur_manual.md
@@ -26,6 +26,8 @@ any questions, complaints, or praise, please do not hesitate to [email Pat](mail
 
 Remember to cite mothur:
 
-> Schloss, P.D., et al., Introducing mothur: Open-source, platform-independent, community-supported software for describing and comparing microbial communities. Appl Environ Microbiol, 2009. 75(23):7537-41
+> Schloss PD et al. 2009. Introducing mothur: Open-source, platform-independent, community-supported software for describing and comparing microbial communities. Applied and Environmental Microbiology 75:7537–7541.
 
-See the [citation file](https://github.com/mothur/mothur/blob/master/CITATION.md) for a BibTeX entry.
+See the 
+[citation file](https://github.com/mothur/mothur/blob/master/CITATION.md) for a 
+BibTeX entry.

--- a/_wiki/mothur_manual.md
+++ b/_wiki/mothur_manual.md
@@ -29,5 +29,5 @@ Remember to cite mothur:
 > Schloss PD et al. 2009. Introducing mothur: Open-source, platform-independent, community-supported software for describing and comparing microbial communities. Applied and Environmental Microbiology 75:7537–7541.
 
 See the 
-[citation file](https://github.com/mothur/mothur/blob/master/CITATION.md) for a 
-BibTeX entry.
+[citation file](https://github.com/mothur/mothur/blob/master/CITATION.md) 
+for a BibTeX entry.

--- a/_wiki/mothur_manual.md
+++ b/_wiki/mothur_manual.md
@@ -29,5 +29,5 @@ Remember to cite mothur:
 > Schloss PD et al. 2009. Introducing mothur: Open-source, platform-independent, community-supported software for describing and comparing microbial communities. Applied and Environmental Microbiology 75:7537–7541.
 
 See the 
-[citation file](https://github.com/mothur/mothur/blob/master/CITATION.md) 
+[citation file](https://github.com/mothur/mothur.github.io/blob/master/CITATION.md) 
 for a BibTeX entry.


### PR DESCRIPTION
- Document the `printref` option in `cluster.fit` (resolves #66).
- Made minor edits in `cluster`, `cluster.split`, and `cluster.fit`
- Also added citation instructions for the OptiClust paper and a TODO comment to do the same for OptiFit.